### PR TITLE
Add user-story template to the project

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,24 @@
+---
+name: User Story
+about: A default user story
+title: "(Short name)"
+labels: ''
+assignees: ''
+
+---
+
+## Value statement - a requirement, not a solution
+As a **(role)** 
+I need **(an action)** 
+so that **(a benefit)** 
+
+## Description (Text, Scribble, Wireframe, Design)
+
+## Acceptance criteria
+- [ ] (functional descriptions)
+
+## Tasks
+- [ ] (todos for the team)
+
+## Size
+(small, medium, large)


### PR DESCRIPTION
This pr adds a `user-story` template file to the project. It helps the developer writing a user story very fast.

After the template was added to the project, everyone who is opening an issue have the possibility to choose the story template.

![grafik](https://user-images.githubusercontent.com/54703643/139655671-26e8e7cd-0d27-4b46-9de5-de99a2edc064.png)
![grafik](https://user-images.githubusercontent.com/54703643/139655721-0b6ae63e-4174-4fb1-9a94-7f8fc276345f.png)

The issue wakes up with pre formated text that has to be filled.

![grafik](https://user-images.githubusercontent.com/54703643/139655892-09cf8f7a-86b2-4093-8359-876d76dceed0.png)
 
Normale "blank" issues are further possible.